### PR TITLE
[feature/RF-18] make a layout for authorization pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "file-loader": "^6.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.22.1"
+        "react-router-dom": "^6.22.2"
       },
       "devDependencies": {
         "@babel/core": "^7.23.9",
@@ -4821,9 +4821,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.1.tgz",
-      "integrity": "sha512-zcU0gM3z+3iqj8UX45AmWY810l3oUmXM7uH4dt5xtzvMhRtYVhKGOmgOd1877dOPPepfCjUv57w+syamWIYe7w==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.2.tgz",
+      "integrity": "sha512-+Rnav+CaoTE5QJc4Jcwh5toUpnVLKYbpU6Ys0zqbakqbaLQHeglLVHPfxOiQqdNmUy5C2lXz5dwC6tQNX2JW2Q==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -22086,11 +22086,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.22.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.1.tgz",
-      "integrity": "sha512-0pdoRGwLtemnJqn1K0XHUbnKiX0S4X8CgvVVmHGOWmofESj31msHo/1YiqcJWK7Wxfq2a4uvvtS01KAQyWK/CQ==",
+      "version": "6.22.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.2.tgz",
+      "integrity": "sha512-YD3Dzprzpcq+tBMHBS822tCjnWD3iIZbTeSXMY9LPSG541EfoBGyZ3bS25KEnaZjLcmQpw2AVLkFyfgXY8uvcw==",
       "dependencies": {
-        "@remix-run/router": "1.15.1"
+        "@remix-run/router": "1.15.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -22100,12 +22100,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.22.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.1.tgz",
-      "integrity": "sha512-iwMyyyrbL7zkKY7MRjOVRy+TMnS/OPusaFVxM2P11x9dzSzGmLsebkCvYirGq0DWB9K9hOspHYYtDz33gE5Duw==",
+      "version": "6.22.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.2.tgz",
+      "integrity": "sha512-WgqxD2qySEIBPZ3w0sHH+PUAiamDeszls9tzqMPBDA1YYVucTBXLU7+gtRfcSnhe92A3glPnvSxK2dhNoAVOIQ==",
       "dependencies": {
-        "@remix-run/router": "1.15.1",
-        "react-router": "6.22.1"
+        "@remix-run/router": "1.15.2",
+        "react-router": "6.22.2"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -111,6 +111,6 @@
     "file-loader": "^6.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.1"
+    "react-router-dom": "^6.22.2"
   }
 }

--- a/src/app/appRouter.tsx
+++ b/src/app/appRouter.tsx
@@ -1,11 +1,32 @@
 import { createBrowserRouter } from 'react-router-dom'
+
 import BaseLayout from './layouts/BaseLayout'
+import AuthLayout from './layouts/AuthLayout'
+
 import { MainPage } from '@/pages/main'
+import { LoginPage } from '@/pages/login'
+import { RegistrationPage } from '@/pages/registration'
 
 export const appRouter = createBrowserRouter([
   {
     element: <BaseLayout />,
     errorElement: <div>Error</div>,
     children: [{ path: '/', element: <MainPage /> }]
+  },
+  {
+    path: '/login',
+    element: (
+      <AuthLayout>
+        <LoginPage />
+      </AuthLayout>
+    )
+  },
+  {
+    path: '/registration',
+    element: (
+      <AuthLayout>
+        <RegistrationPage />
+      </AuthLayout>
+    )
   }
 ])

--- a/src/app/layouts/AuthLayout.tsx
+++ b/src/app/layouts/AuthLayout.tsx
@@ -1,0 +1,20 @@
+import { type ReactElement } from 'react'
+
+import { AuthHeader } from '@/widgets/AuthHeader'
+
+import styles from '../styles/authLayout.module.css'
+
+interface AuthLayoutProps {
+  children: ReactElement
+}
+
+const AuthLayout = ({ children }: AuthLayoutProps) => {
+  return (
+    <>
+      <AuthHeader />
+      <main className={styles.main}>{children}</main>
+    </>
+  )
+}
+
+export default AuthLayout

--- a/src/app/styles/authLayout.module.css
+++ b/src/app/styles/authLayout.module.css
@@ -1,0 +1,9 @@
+.main {
+  max-width: 438px;
+  margin-inline: auto;
+  margin-top: 120px;
+  padding: 44px 34px;
+  text-align: center;
+  border-radius: 12px;
+  background-color: var(--clr-secondary-1); 
+}

--- a/src/features/authentication/login/index.ts
+++ b/src/features/authentication/login/index.ts
@@ -1,0 +1,3 @@
+import LoginForm from './ui/LoginForm'
+
+export { LoginForm }

--- a/src/features/authentication/login/ui/LoginForm.tsx
+++ b/src/features/authentication/login/ui/LoginForm.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom'
+
+import Input from '@/shared/ui/Input/Input'
+import Icon from '@/shared/ui/Icon/Icon'
+import Button from '@/shared/ui/Button/Button'
+
+import styles from './styles.module.css'
+
+const LoginForm = () => {
+  return (
+    <form className={styles.form}>
+      <Input type="text" placeholder="Email Address" leftIcon={<Icon icon="mail" size="20" color="#6e7079" />} />
+      <Input
+        type="password"
+        placeholder="Password"
+        leftIcon={<Icon icon="lock" size="20" color="#6e7079" />}
+        rightIcon={<Icon icon="eye_off" size="20" />}
+      />
+      <Link className={styles.recover} to="/recoverPassword">
+        Recover Password
+      </Link>
+      <p className={styles.signUp}>
+        Don’t have an account? <Link to="/registration">Sign Up</Link>
+      </p>
+      <Button label="Login" />
+    </form>
+  )
+}
+
+export default LoginForm

--- a/src/features/authentication/login/ui/styles.module.css
+++ b/src/features/authentication/login/ui/styles.module.css
@@ -1,0 +1,36 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  margin-top: 60px;
+}
+
+.form > * + * {
+  margin-top: 22px;
+}
+
+.form button {
+  align-self: center;
+  margin-top: 48px;
+}
+
+.recover {
+  align-self: end;
+  margin-top: 4px;
+  color: var(--clr-primary-100);
+}
+
+.recover:hover {
+  text-decoration: underline;
+}
+
+.signUp {
+  margin-top: 48px;
+}
+
+.signUp a {
+  color: var(--clr-primary-100);
+}
+
+.signUp a:hover {
+  text-decoration: underline;
+}

--- a/src/features/authentication/registration/index.ts
+++ b/src/features/authentication/registration/index.ts
@@ -1,0 +1,3 @@
+import RegistrationForm from './ui/RegistrationForm'
+
+export { RegistrationForm }

--- a/src/features/authentication/registration/ui/RegistrationForm.tsx
+++ b/src/features/authentication/registration/ui/RegistrationForm.tsx
@@ -1,0 +1,28 @@
+import { Link } from 'react-router-dom'
+
+import Input from '@/shared/ui/Input/Input'
+import Icon from '@/shared/ui/Icon/Icon'
+import Button from '@/shared/ui/Button/Button'
+
+import styles from './styles.module.css'
+
+const RegistrationForm = () => {
+  return (
+    <form className={styles.form}>
+      <Input type="text" placeholder="Your Full Name" leftIcon={<Icon icon="user" size="20" color="#6e7079" />} />
+      <Input type="text" placeholder="Email Address" leftIcon={<Icon icon="mail" size="20" color="#6e7079" />} />
+      <Input
+        type="password"
+        placeholder="Create a Strong Password"
+        leftIcon={<Icon icon="lock" size="20" color="#6e7079" />}
+        rightIcon={<Icon icon="eye_off" size="20" />}
+      />
+      <p className={styles.login}>
+        Already have an account? <Link to="/login">Login</Link>
+      </p>
+      <Button label="Login" />
+    </form>
+  )
+}
+
+export default RegistrationForm

--- a/src/features/authentication/registration/ui/styles.module.css
+++ b/src/features/authentication/registration/ui/styles.module.css
@@ -1,0 +1,36 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  margin-top: 60px;
+}
+
+.form > * + * {
+  margin-top: 22px;
+}
+
+.form button {
+  align-self: center;
+  margin-top: 48px;
+}
+
+.recover {
+  align-self: end;
+  margin-top: 4px;
+  color: var(--clr-primary-100);
+}
+
+.recover:hover {
+  text-decoration: underline;
+}
+
+.login {
+  margin-top: 48px;
+}
+
+.login a {
+  color: var(--clr-primary-100);
+}
+
+.login a:hover {
+  text-decoration: underline;
+}

--- a/src/pages/login/index.ts
+++ b/src/pages/login/index.ts
@@ -1,0 +1,3 @@
+import LoginPage from './ui/Page'
+
+export { LoginPage }

--- a/src/pages/login/ui/Page.tsx
+++ b/src/pages/login/ui/Page.tsx
@@ -1,0 +1,19 @@
+import { LoginForm } from '@/features/authentication/login'
+import Logo from '@/shared/ui/Logo/logo'
+
+import styles from './styles.module.css'
+
+const LoginPage = () => {
+  return (
+    <>
+      <div className={styles.info}>
+        <Logo icon="logo" withText={false} />
+        <strong className={styles.subtitle}>Welcome back!</strong>
+        <h1 className={styles.title}>Login to your account</h1>
+      </div>
+      <LoginForm />
+    </>
+  )
+}
+
+export default LoginPage

--- a/src/pages/login/ui/styles.module.css
+++ b/src/pages/login/ui/styles.module.css
@@ -1,0 +1,18 @@
+.info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.subtitle {
+  margin-top: 30px;
+  font-size: var(--fs-sh3);
+}
+
+.title {
+  margin-top: 10px;
+  line-height: 1.1;
+  font-size: var(--fs-p2);
+  color: var(--clr-black-30);
+  font-weight: 400;
+}

--- a/src/pages/registration/index.ts
+++ b/src/pages/registration/index.ts
@@ -1,0 +1,3 @@
+import RegistrationPage from './ui/Page'
+
+export { RegistrationPage }

--- a/src/pages/registration/ui/Page.tsx
+++ b/src/pages/registration/ui/Page.tsx
@@ -1,0 +1,21 @@
+import { RegistrationForm } from '@/features/authentication/registration'
+import Logo from '@/shared/ui/Logo/logo'
+
+import styles from './styles.module.css'
+
+const RegistrationPage = () => {
+  return (
+    <>
+      <div className={styles.info}>
+        <Logo icon="logo" withText={false} />
+        <strong className={styles.subtitle}>
+          Get Started with <span>Metrix</span>
+        </strong>
+        <h1 className={styles.title}>Create your free account</h1>
+      </div>
+      <RegistrationForm />
+    </>
+  )
+}
+
+export default RegistrationPage

--- a/src/pages/registration/ui/styles.module.css
+++ b/src/pages/registration/ui/styles.module.css
@@ -1,0 +1,22 @@
+.info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.subtitle {
+  margin-top: 30px;
+  font-size: var(--fs-sh3);
+}
+
+.subtitle span {
+  color: var(--clr-primary-100);
+}
+
+.title {
+  margin-top: 10px;
+  line-height: 1.1;
+  font-size: var(--fs-p2);
+  color: var(--clr-black-30);
+  font-weight: 400;
+}

--- a/src/shared/styles/global.css
+++ b/src/shared/styles/global.css
@@ -33,6 +33,10 @@ html {
   line-height: 1.5;
 }
 
+body {
+  background-color: var(--clr-secondary-2);
+}
+
 button,
 input,
 textarea,

--- a/src/shared/styles/theme.css
+++ b/src/shared/styles/theme.css
@@ -33,6 +33,7 @@
 
   /* color для второстепенного цвета */
   --clr-secondary-1: #fff;
+  --clr-secondary-2: #f4f5fa;
   --clr-secondary-10: #fef9f2;
   --clr-secondary-20: #fef5ea;
   --clr-secondary-30: #fff2e2;

--- a/src/shared/ui/Icon/assets/index.ts
+++ b/src/shared/ui/Icon/assets/index.ts
@@ -20,7 +20,7 @@ const icons = {
   lock,
   mail,
   eye,
-  user
+  user,
   logo
 }
 

--- a/src/shared/ui/Logo/logo.stories.tsx
+++ b/src/shared/ui/Logo/logo.stories.tsx
@@ -1,4 +1,5 @@
-import Logo from './Logo'
+import Logo from './logo'
+
 import '../../styles/theme.css'
 
 export default {

--- a/src/widgets/AuthHeader/index.ts
+++ b/src/widgets/AuthHeader/index.ts
@@ -1,0 +1,3 @@
+import AuthHeader from './ui/AuthHeader'
+
+export { AuthHeader }

--- a/src/widgets/AuthHeader/ui/AuthHeader.tsx
+++ b/src/widgets/AuthHeader/ui/AuthHeader.tsx
@@ -1,0 +1,13 @@
+import Logo from '@/shared/ui/Logo/logo'
+
+import styles from './styles.module.css'
+
+const AuthHeader = () => {
+  return (
+    <header className={styles.header}>
+      <Logo icon="logo" size="36" withText={false} />
+    </header>
+  )
+}
+
+export default AuthHeader

--- a/src/widgets/AuthHeader/ui/styles.module.css
+++ b/src/widgets/AuthHeader/ui/styles.module.css
@@ -1,0 +1,4 @@
+.header {
+  padding: 16px 86px;
+  background-color: var(--clr-secondary-1);
+}


### PR DESCRIPTION
В 1 коммите я исправил ошибки, которые появились после решения конфликта.
Во 2 коммите уже моя задача:

- Я не стал создавать компонент универсальный Header, так как header на странице авторизации отличается от header на других layout
- Я думал сделать еще AuthPage, чтобы туда вынести header и Outlet. Это позволило бы избавится от верстки внутри AuthLayout. Ведь внутри AuthLayout мы будем проверять юзера на авторизацию. Пока не очень ясно как лучше разделять обязанности
- По поводу цвета Logo, я решил оставить пока как есть, нужно будет пофиксить, чтобы в Logo можно было передавать цвет Logo. По идее иконка должна была импортироваться с жестко заданными значениями. но при использовании цвета fill переписываются на currentColor.
- Что касается LoginForm, то я думал о том, чтобы вынести в отдельную компоненту. Ведь там layout повторяется. Но пока решил оставить так. Если надо, то я создам компонент-обертку и туда буду передавать данные в виде props.
- До сих пор не понял по поводу контейнера, что там должно быть? Например, у нас в проекте есть класс container, он оборачивает Outlet в компоненте BaseLayout
- Зачем здесь footer? В задачи сказано, что нужно сделать footer. 

Вот как выглядит пока что страницы авторизации:
![image_2024-03-08_14-57-30](https://github.com/MirgradR/metrix-web-client/assets/60789378/d8f91ae7-fbe3-4672-90d5-8c859eae7f5c)
![image_2024-03-08_15-28-47](https://github.com/MirgradR/metrix-web-client/assets/60789378/e604fc91-b767-4364-b361-a1423239cfe2)
